### PR TITLE
SUP-41810: Fix sorting of schedule collections with multi-level sorter LIEGE

### DIFF
--- a/news/SUP-41810.bugfix
+++ b/news/SUP-41810.bugfix
@@ -1,0 +1,2 @@
+Fix sorting of schedule collections with multi-level sorter
+[daggelpop]

--- a/src/imio/schedule/collectionwidget/vocabulary.py
+++ b/src/imio/schedule/collectionwidget/vocabulary.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from collective.eeafaceted.collectionwidget.vocabulary import CollectionVocabulary
+from imio.schedule.utils import MultiLevelOrdering
 
 from plone import api
 
@@ -22,14 +23,21 @@ class ScheduleCollectionVocabulary(CollectionVocabulary):
         collections_brains = []
         for brain in config_brains:
             config = brain.getObject()
-            brains = catalog(
+            config_collection_brains = catalog(
                 path={
                     "query": "/".join(config.getPhysicalPath()),
                 },
                 object_provides="plone.app.collection.interfaces.ICollection",
-                sort_on="getObjPositionInParent",
             )
-            collections_brains.extend(brains)
+
+            # sort the collections in the same way as in schedule config
+            mlo = MultiLevelOrdering(config)
+            config_collection_brains = sorted(
+                config_collection_brains,
+                key=lambda brain: mlo.get_order(brain.getPath().split("/")),
+            )
+
+            collections_brains.extend(config_collection_brains)
         collections_brains = [
             b for b in collections_brains if b.getObject().aq_parent.enabled
         ]

--- a/src/imio/schedule/utils.py
+++ b/src/imio/schedule/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from OFS.interfaces import IOrderedContainer
 from eea.facetednavigation.layout.interfaces import IFacetedLayout
 
 from imio.dashboard.browser.facetedcollectionportlet import Assignment
@@ -221,3 +222,49 @@ class WorkingDaysCalendar(Belgium):
             or []
         )
         return [matching[d] for d in days]
+
+
+class MultiLevelOrdering:
+    """
+    Initialize with a Folderish object as context.
+
+    Calling the `get_order` method with the path of a descendant of the context
+    will give its relative order among all the descendants of the context.
+    """
+
+    def __init__(self, context):
+        self.orders = {}
+        self.context = context
+        self.context_path = context.getPhysicalPath()
+        self._compute_orderings()
+
+    def _compute_orderings(self):
+        portal = api.portal.get()
+        portal.ZopeFindAndApply(
+            self.context, search_sub=True, apply_func=self._get_position_in_parent
+        )
+
+    def _get_position_in_parent(self, obj, path):
+        if not path:
+            return
+        parent = obj.__parent__
+        ordered = IOrderedContainer(parent, None)
+        if ordered is not None:
+            order = ordered.getObjectPosition(obj.getId())
+            if order is not None:
+                self.orders[path.lstrip("/")] = order
+        return
+
+    def get_order(self, path_tuple):
+        """
+        :param path_tuple: physical path parts pf a descendant of context
+        :rtype: tuple of position numbers
+
+        E.g. ("schedule", "reception", "dashboard_collection") => [2, 3, 0]
+        """
+        order_numbers = []
+        relative_path = path_tuple[len(self.context_path) :]
+        for i in range(len(relative_path)):
+            path_chunk = "/".join(relative_path[: i + 1])
+            order_numbers.append(self.orders[path_chunk])
+        return order_numbers


### PR DESCRIPTION
Replaces getObjPositionInParent to sort brains in a multi-level structure.

Same development as in SUP-42934 (https://github.com/IMIO/imio.schedule/pull/14)